### PR TITLE
Handler was restarting cron, not docker

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: restart docker
-  systemd: state=restarted daemon_reload=yes name=crond
+  systemd: state=restarted daemon_reload=yes name=docker
   listen: "restart docker service"


### PR DESCRIPTION
One-liner with fix to properly restart docker, as the description suggests.

Tested on my local environment and proven to work properly.