### PR TITLE
Add pip to required packages

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,6 +6,7 @@
     - apt-transport-https
     - ca-certificates
     - openssl
+    - python-pip
 
 - name: Add docker.io repo
   apt_repository: repo='deb https://apt.dockerproject.org/repo debian-jessie main' state=present


### PR DESCRIPTION
Fixes `Unable to find any of pip2, pip to use.  pip needs to be installed.` when the target node has no `pip` yet.